### PR TITLE
Delete duplicate server

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -61,10 +61,6 @@
     "address": ["meowisland.ru:6000", "meowisland.ru:6001"]
   },
   {
-    "name": "The Devil",
-    "address": ["new.xem8k5.top:6568"]
-  },
-  {
     "name": "AzurLine",
     "address": ["78.47.238.87", "78.47.238.87:6568", "78.47.238.87:6569"]
   },


### PR DESCRIPTION
It already exists, so it will cause the server list to show the server twice.
@xem8k5 