### PR TITLE
Expand Mindustry Tool servers to give players more choices

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "Mindustry Tool",
-    "address": ["server.mindustry-tool.com:10000", "server.mindustry-tool.com:10001", "server.mindustry-tool.com:10002", "server.mindustry-tool.com:10003", "server.mindustry-tool.com:10004", "server.mindustry-tool.com:10005"]
+    "address": ["server.mindustry-tool.com:10000", "server.mindustry-tool.com:10001", "server.mindustry-tool.com:10002", "server.mindustry-tool.com:10003", "server.mindustry-tool.com:10004", "server.mindustry-tool.com:10005", "server.mindustry-tool.com:10006", "server.mindustry-tool.com:10007", "server.mindustry-tool.com:10008", "server.mindustry-tool.com:10009", "server.mindustry-tool.com:10010"]
   },
   {
     "name": "IndustryCats",


### PR DESCRIPTION
We’re expanding the Mindustry Tool server cluster to make it easier for players to find open and stable servers to play on.

**What’s new:**
- Added more servers:
  - server.mindustry-tool.com:10006  
  - server.mindustry-tool.com:10007  
  - server.mindustry-tool.com:10008  
  - server.mindustry-tool.com:10009  
  - server.mindustry-tool.com:10010

**Why:**
The first few servers (10000–10005) have been running smoothly and received great support from players.   To keep things stable and give everyone more room to play together, we’re adding more servers to the cluster.