### PR TITLE
REMOVE "Mutsumi daisuki" Server from servers_v8.json Due to Privacy Violations

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -152,10 +152,6 @@
     "address": ["mindustry.net.cn:20008", "new.mindustry.net.cn:20008"]
   },
   {
-    "name": "Mutsumi daisuki",
-    "address": ["45.125.44.66:15143", "45.125.44.66:15142", "114.66.49.107"]
-  },
-  {
     "name": "Lett's Server Network",
     "address": ["sandbox.lettsn.org"]
   },


### PR DESCRIPTION
This pull request removes the server entry for "Mutsumi daisuki" from the servers_v8.json file. The removal is necessary because this server has been observed displaying players' UUIDs (unique identifiers) and IP addresses when kicking them out. This behavior constitutes a severe privacy infringement, as it exposes sensitive personal information that could lead to data leaks or misuse. Such actions directly violate server regulations that mandate the protection of user privacy and prohibit unauthorized disclosure of identifying details. By removing this server, we aim to uphold privacy standards, prevent potential security risks, and ensure compliance with our established rules for a safe and respectful gaming environment.
<img width="1121" height="77" alt="801fb23557dfacefd92b26a41315671c" src="https://github.com/user-attachments/assets/83524bb8-b44b-49f5-802f-fe09d7739ae0" />
