### PR TITLE
remove my server form list

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -229,9 +229,5 @@
   {
     "name": "MDN",
     "address": ["mindustry.ddns.net:2001"]
-  },
-  {
-    "name": "StarLegends",
-    "address": ["h1.getmc.cn:33455", "h1.getmc.cn:34563"]
   }
 ]


### PR DESCRIPTION
Exposing a server that is not ready to be public is not a good idea, players are suffering damage caused by strangers, especially recently from malicious players. I have decided to remove the server from the list.