### PR TITLE
MDN V8 Migration

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -254,7 +254,7 @@
   },
   {
     "name": "MDN",
-    "address": ["mindustry.ddns.net:2001"]
+    "address": ["mindustry.ddns.net:1000", "mindustry.ddns.net:2000", "mindustry.ddns.net:3000", "mindustry.ddns.net:4000", "mindustry.ddns.net:5000"]
   },
   {
     "name": "Cyandustry",


### PR DESCRIPTION
Removed port 2001, as that'll be changed to a whitelist server after V8's official release.

Added the other modes, ranging from ports 1000 to 5000; increments of 1000 and inclusive.

This is in anticipation of the official release of V8.