### PR TITLE
Add Blyss Mindustry server

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -310,5 +310,9 @@
   {
     "name": "EV's ranked PvP server",
     "address": ["evrankedpvp.ddns.net"]
+  },
+  {
+    "name": "Blyss Mindustry",
+    "address": ["31.58.77.143"]
   }
 ]


### PR DESCRIPTION
## Summary

Adding **Blyss Mindustry**, a Russian-language survival server with an XP-based rank system.

- Address: `31.58.77.143` (port 6567, default)
- Mode: Survival
- Audience: friendly community, Russian-language

## Server checklist

- [x] Appropriate name & description set via `config name/desc`
- [x] `config showConnectMessages false`
- [x] `config messageRateLimit 1`
- [x] `rules add bannedBlocks ["canvas", "logic-display", "large-logic-display"]`
- [x] Latest stable Mindustry server (auto-updates from GitHub releases)

## Note about plugins

The server runs a small custom Java plugin (BlyssPlugin) that provides:
- a localised `/help` and a few player commands (`/me`, `/info`, `/maps`, `/players`, `/rank`, `/top`, `/level`, `/discord`)
- an XP / rank progression on top of normal survival play (per-minute, per-block, per-wave)

The plugin **does not introduce any custom content** (no blocks, units, items, statuses, etc.) — it only listens to events and registers commands, so vanilla clients connect without downloading anything.

If having any plugin at all is a hard blocker for inclusion, please let me know and I'll temporarily remove it for review.