### PR TITLE
Add address for Moon server

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -303,7 +303,7 @@
   },
   {
     "name": "Moon",
-    "address": ["srv139.godlike.club:26004"]
+    "address": ["15.235.181.65:26004", "srv139.godlike.club:26004"]
   },
   {
     "name": "Korea",


### PR DESCRIPTION
We were previously using IP, and our IP changed due to hosting service condition update. Now we've added domain address instead of ID, for a more persistent address (Thank you for actioning that so quickly). 

However, it seems now some mobile players are not able to save the server to "Remove Servers" via "+ Add Server". When I tried to add the server, the address comes up as some invalid string. I want to also add our IP under the listing, so players can it to their Remote Servers list.

Essentially, I am asking to add both domain and IP addresses under the server name, both pointing to the same end server.

I don't know if that is allowed, so please let me know if that is an issue.