### PR TITLE
Add Mindustry TOKYO to official server list

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -359,5 +359,12 @@
   {
     "name": "Foundation PvP",
     "address": ["188.126.61.232:6567"]
+　},
+  {
+    "name": "Mindustry TOKYO",
+    "address": [
+      "mindustry-tokyo.xvps.jp:6567",
+      "mindustry-tokyo.xvps.jp:6568"
+    ]
   }
 ]


### PR DESCRIPTION
Hello Anuken,
Please add "Mindustry TOKYO" to the official server list.
We offer a stable server environment for Survival and PVP modes.
I highly value the game balance set by Mr. Anuken. I intend to cultivate players on this server who can efficiently and quickly mass-produce resources and units while staying true to the fundamentals, and who can attack enemies in the best possible way in PVP, all while trying to maintain that balance as much as possible.
Thank you!　　 from onumao