### PR TITLE
Featured Servers section proposal

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -177,6 +177,13 @@
     ]
   },
   {
+    "name": "Featured Servers",
+    "prioritized": true,
+    "address": [
+      "n4.xpdustry.com:50022"
+    ]
+  },
+  {
     "name": "MeowIsland",
     "address": ["meowisland.ru:6000", "meowisland.ru:6001", "meowisland.ru:6002", "meowisland.ru:6003"]
   },


### PR DESCRIPTION
### Summary

Adds an experimental `Featured Servers` server category to the server list.

Stems from an idea I proposed in the Mindustry Server Owners discord.

<img width="1809" height="721" alt="image" src="https://github.com/user-attachments/assets/441090a0-c966-4bd5-ab71-555fe5b8d52f" />

### Links

- https://github.com/Anuken/Mindustry/pull/8720
- https://github.com/Anuken/Mindustry/commit/7fbf4cacad7ee14cbdb79b7231b2175a7ee0e529

### Details

The server is a proxy, running https://github.com/xpdustry/poly.
The proxy can be claimed for a limited time (maximum 24 hours) to route players to the proxied server.
Intended to be used for events.

### Limitations

- Currently, the proxy server can only be controlled if the server owner is in the Mindustry Server Owners discord. I'm trying to figure out a proper way to not require that.
- The poly plugin logs claims in a public discord channel. I haven't added rate limits yet.
- The proxy server is located in EU west (France). It is therefore not guaranteed to be reachable by all other regions. Adding a proxy somewhere else, such as EU east and/or ASIA would be ideal.

### Merge requirements

At least 2 approvals and Anuke.