### PR TITLE
Please add Hex server to Mindustry TOKYO

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -366,7 +366,8 @@
     "name": "Mindustry TOKYO",
     "address": [
       "mindustry-tokyo.xvps.jp:6567",
-      "mindustry-tokyo.xvps.jp:6568"
+      "mindustry-tokyo.xvps.jp:6568",
+      "mindustry-tokyo.xvps.jp:6569"
     ]
   },
   {


### PR DESCRIPTION
 ### Description
Added a new Hex server (port 6569) to the existing "Mindustry TOKYO" server group. 
Our hex mode is very simple and respects Anuken's default settings. Each player only has one core, and we've intentionally made the time limit unlimited, so that each player can enjoy battle royale to their heart's content with a simple system similar to a campaign mode.
Please review and merge it when you have time. Thank you for maintaining the server list!  by onumao