### PR TITLE
Add Sectorized server

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -384,5 +384,9 @@
   {
     "name": "MDT DO",
     "address": ["43.248.117.226:40149"]
+  },
+  {
+    "name": "Sectorized",
+    "address": ["sectorized.freeddns.org"]
   }
 ]


### PR DESCRIPTION
Hello 👋🏻 

This server used to be part of the server list, but got dropped with a never version. I now took the time to migrate the [SectorizedPlugin](https://github.com/Pointifix/SectorizedPlugin) to v158.1 and switched the host of the server, but dns stays the same.

A little about the server:

- FFA but also Survival as Crux Unit waves force a game end by getting ever stronger
- Custom hex like gamemode where the buildable area per player can be expanded by placing cores that cost resources displayed in the HUD
- Randomly generated maps with biomes and rivers
- Players can play solo but also form teams
- Features a high-score list regularely posted on the [discord server sectorized](https://discord.gg/AmdMXKkS9Q)

<img width="751" height="753" alt="image" src="https://github.com/user-attachments/assets/8fe4905d-546a-4548-b653-6af3808e8e3c" />

Name/Address:

- **name:** Sectorized
- **address:** sectorized.freeddns.org