### PR TITLE
Add Magyar Mindustry

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -404,5 +404,9 @@
   {
     "name": "doLdoQ",
     "address": ["play.simpfun.cn:14887"]
+  }.
+  {
+    "name": "Magyar Mindustry",
+    "address": ["tisza.gergo.top:6567", "duna.gergo.top:6568", "drava.gergo.top:6590", "raba.gergo.top:6591"]
   }
 ]

--- a/servers_v8.json
+++ b/servers_v8.json
@@ -404,7 +404,7 @@
   {
     "name": "doLdoQ",
     "address": ["play.simpfun.cn:14887"]
-  }.
+  },
   {
     "name": "Magyar Mindustry",
     "address": ["tisza.gergo.top:6567", "duna.gergo.top:6568", "drava.gergo.top:6590", "raba.gergo.top:6591"]


### PR DESCRIPTION
Returning network, last seen at v5/v6 :)

Adding 2 placeholders (Drava + Raba), once modes are decided this/next week, they will be live also.
Live servers are Tisza (PvP) and Duna (Attack)