### PR TITLE
Add RU server for fast PVP battles

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -416,5 +416,9 @@
   {
     "name": "touhou",
     "address": ["140.210.15.169:6567"]
+  },
+  {
+    "name": "MindCup RUS / PVP",
+    "address": ["MindCup.ru"]
   }
 ]


### PR DESCRIPTION
as one of the moderators of the Claj node RU segment, I listened to the players and decided to allow the launch of a PvP server. We would like to publicly add it to the list of servers.

All the developer's wishes have been taken into account, without the need for client-side mods, using server-side solutions (all the server plugins in my repository that have been used https://github.com/TOWUK?tab=repositories) for game administration, some optimizations, and updates from the game developer, with 24/7 access and timely server updates.