### PR TITLE
Remove Charophyceae server addresses from the list, since both of the addresses are down

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -202,7 +202,7 @@
   },
   {
     "name": "Charophyceae",
-    "address": ["46.4.114.111", "ns.charo.qzz.io:25029"]
+    "address": []
   },
   {
     "name": "MAL",


### PR DESCRIPTION
The server seems to be down for like 5 days already, the numeric address just times out and the domain one is unreachable