### PR TITLE
Update server address for The Domain of Light

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -245,7 +245,7 @@
   },
   {
     "name": "The Domain of Light",
-    "address": ["play.simpfun.cn:26054"]
+    "address": ["103.85.86.151:26054"]
   },
   {
     "name": "abcxyz vietnam offical",


### PR DESCRIPTION
The server has not been changed. It has replaced an IP with a lower latency. Because of the restrictions of the service provider, pinging may fail outside Chinese Mainland.

IP is valid

<img width="1600" height="437" alt="Screenshot_20260723_082154" src="https://github.com/user-attachments/assets/f9960c47-c7b7-4910-b626-cb389429551b" />
