### PR TITLE
I'm sorry about this. I left a bad IP address 43.248.77.232:26054. Although the ping latency is low, due to the high latency within a single line server, it is now reserved as 119.45.28.241:26054 BGP three line

### DIFF
--- a/servers_v8.json
+++ b/servers_v8.json
@@ -245,7 +245,7 @@
   },
   {
     "name": "The Domain of Light",
-    "address": ["43.248.77.232:26054"]
+    "address": ["119.45.28.241:26054"]
   },
   {
     "name": "abcxyz vietnam offical",


### PR DESCRIPTION
…though the ping latency is low, due to the high latency within a single line server, it is now reserved as 119.45.28.241:26054 BGP three line